### PR TITLE
Permalink now using screenname rather than display name

### DIFF
--- a/simple-twitter-tweets.php
+++ b/simple-twitter-tweets.php
@@ -460,7 +460,7 @@ class PI_SimpleTwitterTweets extends WP_Widget{
 						// COMMUNITY REQUEST !!!!!! (2)
 						$screen_name = $tweet->user->screen_name;
 
-						$permalink = 'http://twitter.com/'. $name .'/status/'. $tweet->id_str;
+						$permalink = 'http://twitter.com/'. $screen_name .'/status/'. $tweet->id_str;
 						$tweet_id = $tweet->id_str;
 
 						/* Alternative image sizes method: http://dev.twitter.com/doc/get/users/profile_image/:screen_name */


### PR DESCRIPTION
Previously it would use the display name which in my case even included
spaces. At this point, $permalink is not being used anywhere, so the
bug was missed. Thus, applying this commit does not change any
behaviour.
